### PR TITLE
separate public and private repo instructions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,9 @@
 # Security Policy
 
-To report a security issue, please use https://hackerone.com/netlify?type=team.
+When submitting a security issue, always include: Summary, Impact, and Reproduction steps that are as clear as possible.
 
-The Netlify Security Team will respond as soon as possible.
+- To report a security issue on public repos, please use https://hackerone.com/netlify?type=team.
+    - The Netlify Security Team will respond as soon as possible.
+    - Any coordination and disclosure will be done using the Hackerone UI in order to privately discuss and fix the issue.
 
-Any coordination and disclosure will be done using the Hackerone UI in order to privately discuss and fix the issue.
-
+- To report a security issue on a private repo, please open the issue with the label `security`, and the Netlify Security Team will triage and perform an initial risk assessment.


### PR DESCRIPTION
Minor update to SECURITY.md community health file advocating that security issues on public repos are directed to our bug bounty program, whereas security issues on private repos are triaged directly in the repo.